### PR TITLE
ActiveResource integration fixes

### DIFF
--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -41,6 +41,8 @@ module ShopProductSink
     end
 
     def shopify_resource
+    	# set site to string or ActiveResource raises on call to .prefix on nil
+    	ShopifyAPI::Base.site = '' if ShopifyAPI::Base.site.nil?
       ShopifyAPI::Product
     end
 

--- a/app/models/shop_product_sink/api_creatable.rb
+++ b/app/models/shop_product_sink/api_creatable.rb
@@ -34,8 +34,11 @@ module ShopProductSink
 
     def extract_relations!(resource)
       self.class.reflect_on_all_associations.each do |association|
-        if resource.respond_to?(association.name)
-          resource_or_resources = resource.public_send(association.name)
+      	# workaround for variants association name
+      	association_name = association.name == :product_variants ? :variants : association.name
+
+        if resource.respond_to?(association_name)
+          resource_or_resources = resource.public_send(association_name)
           records = association.klass.initialize_from_resources(resource_or_resources)
           public_send("#{association.name}=", association.collection? ? records : records.first)
         end

--- a/app/models/shop_product_sink/product.rb
+++ b/app/models/shop_product_sink/product.rb
@@ -1,7 +1,7 @@
 module ShopProductSink
   class Product < ActiveRecord::Base
     include ApiCreatable
-    has_many :product_variants
-    has_many :options
+    has_many :product_variants, dependent: :delete_all
+    has_many :options, dependent: :delete_all
   end
 end

--- a/app/models/shop_product_sink/webhooks.rb
+++ b/app/models/shop_product_sink/webhooks.rb
@@ -67,7 +67,7 @@ module ShopProductSink
     end
 
     def delete?
-      event = 'delete'
+      event == 'delete'
     end
 
     private

--- a/shop_product_sink.gemspec
+++ b/shop_product_sink.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0.2"
+  s.add_dependency "rails", ">= 4.0.2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "shopify_api"

--- a/test/controllers/shop_product_sink/webhooks_controller_test.rb
+++ b/test/controllers/shop_product_sink/webhooks_controller_test.rb
@@ -4,8 +4,15 @@ module ShopProductSink
   class WebhooksControllerTest < ActionController::TestCase
 
     setup do
+      @routes = Engine.routes
+      @request.env['CONTENT_TYPE'] = 'application/json'
       ShopifyAPI::Base.site = "https://example.myshopify.com/admin"
       WebhooksController.any_instance.stubs(:application_secret).returns('abracadabra')
+      @product_and_relations = [
+        "ShopProductSink::Product.count",
+        "ShopProductSink::ProductVariant.count",
+        "ShopProductSink::Option.count"
+      ]
     end
 
     test "when a product creation event occurs" do
@@ -13,8 +20,8 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_create')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/create'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 247905905
-      assert_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_create')
         assert_response :ok
       end
     end
@@ -24,32 +31,63 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
     end
 
     test "when a product update event occurs and the product has been synchronized" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
-      ShopProductSink::Product.create(id: 156731111)
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      ShopProductSink::ProductVariant.create(product_id: params[:id])
+      ShopProductSink::Option.create(product_id: params[:id])
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_no_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_no_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
     end
 
+    test "when a product update event occurs and the product has been synchronized with a different number of variants and options" do
+      WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      # create two options and variants
+      2.times do |x|
+        ShopProductSink::Option.create(product_id: params[:id])
+        ShopProductSink::ProductVariant.create(product_id: params[:id])
+      end
+
+      @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
+      @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
+      full_json = ShopifyJson.read_full_json('product_update')
+      assert_no_difference "ShopProductSink::Product.count" do
+        post :create, full_json
+        assert_response :ok
+      end
+
+      # new count for variants and options should match json fixture file
+      assert_equal full_json["variants"].size, ShopProductSink::ProductVariant.count, "variants count"
+      assert_equal full_json["options"].size, ShopProductSink::Option.count, "options count"
+    end
+
     test "when a product deletion event occurs" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
-      ShopProductSink::Product.create(id: 156731111)
-      @request.env['RAW_POST_DATA'] = ''
+      # delete webhook json only contains id
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      ShopProductSink::ProductVariant.create(product_id: params[:id])
+      ShopProductSink::Option.create(product_id: params[:id])
+      @request.env['RAW_POST_DATA'] = ActiveSupport::JSON.encode(params)
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/delete'
-      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_difference "ShopProductSink::Product.count", -1 do
-        post :create, use_route: :shop_product_sink
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
+      assert_difference @product_and_relations, -1 do
+        post :create, params
         assert_response :ok
       end
     end
@@ -59,7 +97,7 @@ module ShopProductSink
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
       @request.env['HTTP_X_SHOPIFY_HMAC_SHA256'] = 'dsfdfasfsdafasdfdsa'
-      post :create, use_route: :shop_product_sink
+      post :create, ShopifyJson.read_full_json('product_update')
       assert_response :unauthorized
     end
   end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Dummy::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
@@ -33,4 +33,7 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Random test order like Rails 5
+  config.active_support.test_order = :random
 end

--- a/test/models/shop_product_sink/product_test.rb
+++ b/test/models/shop_product_sink/product_test.rb
@@ -2,8 +2,26 @@ require 'test_helper'
 
 module ShopProductSink
   class ProductTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    test 'that destroying product deletes all dependent variants and options' do
+    	fake_product_id = 9
+    	fake_product = ShopProductSink::Product.create(id: fake_product_id)
+    	ShopProductSink::ProductVariant.create(product_id: fake_product_id)
+    	ShopProductSink::Option.create(product_id: fake_product_id)
+
+    	assert ShopProductSink::Product.count > 0, "should have at least one product fixture loaded"
+
+    	variants = fake_product.product_variants
+    	options = fake_product.options
+
+    	assert variants.count > 0, "product fixture should have variants"
+    	assert options.count > 0, "product fixture should have options"
+
+      assert_difference "ShopProductSink::Product.count", -1 do
+				fake_product.destroy
+			end
+
+			assert_equal 0, variants.reload.count, "variants count should be 0 after destroy"
+			assert_equal 0, options.reload.count, "options count should be 0 after product destroy"
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,9 +37,13 @@ module ShopifyJson
     File.read(File.expand_path("../fixtures/shopify_json/#{filename}.json", __FILE__))
   end
 
-  def self.read_json(filename, root)
+  def self.read_full_json(filename)
     contents = read_file(filename)
-    ActiveSupport::JSON.decode(contents)[root]
+    ActiveSupport::JSON.decode(contents)
+  end
+
+  def self.read_json(filename, root)
+    read_full_json(filename)[root]
   end
 
   def self.product(filename)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "rails/test_help"
 require 'shopify_api'
 require 'pry'
 require 'pry-byebug'
+require 'mocha/mini_test'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
- Fix product-killing typo in Webhooks model delete? method
- Webhooks now create, update and delete Product relations (Variants and Options) reliably
  - More robust testing of webhooks controller with regards to Product relations
- Bring some configs up to date w/ Rails 4.2, to bypass deprecation notices in tests