### PR TITLE
Add product images

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,51 @@ rake shop_product_sink:install:migrations
 rake db:migrate SCOPE=shop_product_sink
 ```
 
+### Shop Scoping
+
+Add shop scoping to your products in a couple of steps. You'll need a `Shop` model, which can be looked up by the shop's myshopify.com domain.
+
+**1. Add a `has_many :products` association to your shop model**
+
+```ruby
+# app/models/shop.rb
+class Shop < ActiveRecord::Base
+  has_many :products, class_name: 'ShopProductSink::Product'
+end
+```
+Note: the `class_name` must be set to the engine's Product model.
+
+**2. Set the shop class name in an initializer**
+
+```ruby
+# config/initializers/shop_product_sink.rb
+# Set the model that ShopProductSink::Product will belong to
+ShopProductSink.shop_class = 'Shop'
+```
+This will set the belongs_to relation for `ShopProductSink::Product`. Set it as a string.
+
+**3. Let the `ShopProductSink` know how to find
+a single shop based on its shopify domain**
+
+By default, `ShopProductSink` will look up the shop using your `Shop` model's `find_by_domain` method. So, if your Shop model has a `domain` attribute that corresponds to the Shop's myshopify domain (e.g., *bagelshop.myshopify.com*), then you're set. 
+
+Otherwise, you'll need to add your own method to look up a shop by its myshopify.com domain:
+
+```ruby
+# app/models/shop.rb
+def self.find_by_shop_domain(shop_domain)
+  self.where(myshopify_domain: shop_domain).first
+end
+```
+```ruby
+# config/initializers/shop_product_sink.rb
+# Set the method within shop_class above to lookup a shop by its myshopify.com domain
+ShopProductSink.shop_lookup_method = :find_by_shop_domain
+```
+
+#### Upgrading an existing install to use shop scoping
+If you're already using `ShopProductSink` in a current app, repeat the "Install and Run migrations" step above to add a `shop_id` column to the `shop_product_sink_products` table.
+
 ## Usage
 
 The engine comes with two utility functions that make it easier to integrate
@@ -83,24 +128,14 @@ want to handle validating webhooks on your own.
 Rails.application.routes.default_url_options[:host] = "your.domain.tld"
 ```
 
-**2. In an initializer let the `ShopProductSink::WebhooksController` know how to find
-a single shop based on it's shopify domain**
-
-```ruby
-# config/initializers/shop_product_sink.rb
-ShopProductSink::WebhooksController.shop_retrieval_strategy = -> (shopify_domain) {
-  Shop.where(domain: shopify_domain).first
-}
-```
-
-**3. Include your Application Secret in your ENV**
+**2. Include your Application Secret in your ENV**
 
 You should probably be doing this already anyway since it's good practice. The only problem
 is you are somewhat forced onto a naming convention for at least one of your API variables.
 
 The variable that needs to be set in your environment is `SHOPIFY_API_SECRET`
 
-**4. Register to receive Product change webhooks whenever it is necessary**
+**3. Register to receive Product change webhooks whenever it is necessary**
 
 ```ruby
 ShopProductSink::WebhookRegistration.register(
@@ -111,11 +146,9 @@ ShopProductSink::WebhookRegistration.register(
 
 ### I don't want to use your WebhooksController because XYZ
 
-You don't have to!!!
+You don't have to!!! If you want you can create your own webhooks handler.
 
-If you want you can create your own webhooks handler and just include the `ShopProductSink::Webhooks` module in it.
+You are required to do a few things if you use your own webhooks controller/handler:
 
-You are required to do a few things if you use this:
-
-1. Set the `shop_retrieval_strategy`
+1. Include the `ShopProductSink::Webhooks` module in it.
 2. Implement `application_secret`

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Shopify by keeping a shops products synchronized with a local copy.
 
 ## Wanted Features / Todo List
 
-1. Provide a default webhooks controller that will do basic product synchronization
-2. Do proper shop scoping since right now there isn't any and there could possibly be some data leakage
-3. Refactor API createable integration objects such that them and their migrations aren't imported when the engine is installed
-4. Remove all CSS and JavaScript since it's not actually needed for this engine to work whatsoever
+- [ ] Provide a default webhooks controller that will do basic product synchronization
+- [x] Do proper shop scoping since right now there isn't any and there could possibly be some data leakage
+- [ ] Refactor API createable integration objects such that them and their migrations aren't imported when the engine is installed
+- [ ] Remove all CSS and JavaScript since it's not actually needed for this engine to work whatsoever
 
 ## Setup
 
@@ -41,7 +41,7 @@ Mount the application in your routes file:
 mount ShopProductSink::Engine, at: "product_sink"
 ```
 
-Install and Run the migrations:
+### Install and Run the migrations:
 
 ```
 rake shop_product_sink:install:migrations
@@ -90,8 +90,16 @@ end
 ShopProductSink.shop_lookup_method = :find_by_shop_domain
 ```
 
-#### Upgrading an existing install to use shop scoping
-If you're already using `ShopProductSink` in a current app, repeat the "Install and Run migrations" step above to add a `shop_id` column to the `shop_product_sink_products` table.
+## Upgrading
+If your app is already using `ShopProductSink`, upgrading is similar to setup.
+
+1. Update the gem using bundler:
+
+`bundle update shop_product_sink`
+
+2. Go through the **Install and Run migrations** step above to update your database tables.
+
+3. Go through the steps for **Shop Scoping** above if your app will be used by multiple shops.
 
 ## Usage
 
@@ -143,6 +151,8 @@ ShopProductSink::WebhookRegistration.register(
   token: 'abracadabra'
 )
 ```
+
+That's all you need. As product webhooks come in, ShopProductSink will keep local product data in sync with Shopify's for the shop in question.
 
 ### I don't want to use your WebhooksController because XYZ
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Rails.application.routes.default_url_options[:host] = "your.domain.tld"
 You should probably be doing this already anyway since it's good practice. The only problem
 is you are somewhat forced onto a naming convention for at least one of your API variables.
 
-The variable that needs to be set in your environment is `SHOPIFY_API_SECRET`
+The variable that needs to be set in your environment is `SHOPIFY_APP_SECRET`
 
 **3. Register to receive Product change webhooks whenever it is necessary**
 

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -41,8 +41,8 @@ module ShopProductSink
     end
 
     def shopify_resource
-    	# set site to string or ActiveResource raises on call to .prefix on nil
-    	ShopifyAPI::Base.site = '' if ShopifyAPI::Base.site.nil?
+      # set site to string or ActiveResource raises on call to .prefix on nil
+      ShopifyAPI::Base.site = '' if ShopifyAPI::Base.site.nil?
       ShopifyAPI::Product
     end
 
@@ -51,7 +51,9 @@ module ShopProductSink
     end
 
     def initialize_model
-      resource_class.initialize_from_resource(shopify_object)
+      model = resource_class.initialize_from_resource(shopify_object)
+      model.shop_id = shop_id
+      model
     end
   end
 end

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -3,6 +3,7 @@ require_dependency "shop_product_sink/application_controller"
 module ShopProductSink
   class WebhooksController < ApplicationController
     include ShopProductSink::Webhooks
+    include ShopProductSink::Shop
 
     def create
       handle_creation

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -12,7 +12,7 @@ module ShopProductSink
     end
 
     def application_secret
-      ENV['SHOPIFY_API_SECRET']
+      ENV['SHOPIFY_APP_SECRET'] || ENV['SHOPIFY_API_SECRET']
     end
 
     def handle_creation

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -17,7 +17,7 @@ module ShopProductSink
 
     def handle_creation
       return unless create?
-      initialize_model.save!
+      initialize_model.save! unless resource_class.exists?(resource_id)
     end
 
     def handle_update

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -42,8 +42,6 @@ module ShopProductSink
     end
 
     def shopify_resource
-      # set site to string or ActiveResource raises on call to .prefix on nil
-      ShopifyAPI::Base.site = '' if ShopifyAPI::Base.site.nil?
       ShopifyAPI::Product
     end
 

--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -41,6 +41,8 @@ module ShopProductSink
     end
 
     def shopify_resource
+    	# set site to string or ActiveResource raises on call to .prefix on nil
+    	ShopifyAPI::Base.site = '' if ShopifyAPI::Base.site.nil?
       ShopifyAPI::Product
     end
 

--- a/app/models/shop_product_sink/api_creatable.rb
+++ b/app/models/shop_product_sink/api_creatable.rb
@@ -19,8 +19,7 @@ module ShopProductSink
 
       def create_from_resource(resource, shop_id = nil)
         object = initialize_from_resource(resource)
-        # TODO: make this column name configurable
-        object.shop_id = shop_id if shop_id && objects.respond_to?(:shop_id)
+        object.shop_id = shop_id if shop_id && object.respond_to?(:shop_id)
         object.save
         object
       end

--- a/app/models/shop_product_sink/api_creatable.rb
+++ b/app/models/shop_product_sink/api_creatable.rb
@@ -17,14 +17,16 @@ module ShopProductSink
         Array[*resources].flatten.map { |resource| initialize_from_resource(resource) }
       end
 
-      def create_from_resource(resource)
+      def create_from_resource(resource, shop_id = nil)
         object = initialize_from_resource(resource)
+        # TODO: make this column name configurable
+        object.shop_id = shop_id if shop_id && objects.respond_to?(:shop_id)
         object.save
         object
       end
 
-      def create_from_resources(resources)
-        Array[*resources].flatten.map { |resource| create_from_resource(resource) }
+      def create_from_resources(resources, shop_id = nil)
+        Array[*resources].flatten.map { |resource| create_from_resource(resource, shop_id) }
       end
 
       def usable_keys

--- a/app/models/shop_product_sink/api_creatable.rb
+++ b/app/models/shop_product_sink/api_creatable.rb
@@ -34,8 +34,11 @@ module ShopProductSink
 
     def extract_relations!(resource)
       self.class.reflect_on_all_associations.each do |association|
-        if resource.respond_to?(association.name)
-          resource_or_resources = resource.public_send(association.name)
+      	# workaround for variants association name
+      	association_name = association.name == :product_variants ? :variants : association.name
+
+        if resource.respond_to?(association_name)
+          resource_or_resources = resource.public_send(association_name)
           records = association.klass.initialize_from_resources(resource_or_resources)
           public_send("#{association.name}=", association.collection? ? records : records.first)
         end

--- a/app/models/shop_product_sink/image.rb
+++ b/app/models/shop_product_sink/image.rb
@@ -1,0 +1,6 @@
+module ShopProductSink
+  class Image < ActiveRecord::Base
+    include ApiCreatable
+    belongs_to :product
+  end
+end

--- a/app/models/shop_product_sink/importers/product.rb
+++ b/app/models/shop_product_sink/importers/product.rb
@@ -31,7 +31,7 @@ module ShopProductSink
       end
 
       def fetch(page, limit)
-        ShopifyAPI::Product.find(:all, query: {page: page, limit: limit}) || []
+        ShopifyAPI::Product.find(:all, params: {page: page, limit: limit}) || []
       end
 
       def shopify_shop_domain(options = {})

--- a/app/models/shop_product_sink/importers/product.rb
+++ b/app/models/shop_product_sink/importers/product.rb
@@ -11,6 +11,7 @@ module ShopProductSink
 
       def import(options={})
         products = retrieve(options)
+        # TODO: add shop relation to products when importing
         ShopProductSink::Product.create_from_resources(products)
       end
 

--- a/app/models/shop_product_sink/importers/product.rb
+++ b/app/models/shop_product_sink/importers/product.rb
@@ -1,21 +1,24 @@
 module ShopProductSink
   module Importers
     class Product
+      include ShopProductSink::Shop
+
       PAGE_SIZE = 250
 
       attr_accessor :session
       def initialize(options = {})
         setup_private_app(options[:site])
         setup_partner_app(options.except(:site))
+        shopify_shop_domain(options)
       end
 
       def import(options={})
         products = retrieve(options)
-        # TODO: add shop relation to products when importing
-        ShopProductSink::Product.create_from_resources(products)
+        ShopProductSink::Product.create_from_resources(products, shop_id)
       end
 
       def retrieve(options={})
+        # FIXME: pagination stops at page 1 and/or 50 products
         products = []
         limit = options[:limit] || PAGE_SIZE
         page = 1
@@ -29,6 +32,10 @@ module ShopProductSink
 
       def fetch(page, limit)
         ShopifyAPI::Product.find(:all, query: {page: page, limit: limit}) || []
+      end
+
+      def shopify_shop_domain(options = {})
+        @shopify_shop_domain ||= options[:shop]
       end
 
       private

--- a/app/models/shop_product_sink/product.rb
+++ b/app/models/shop_product_sink/product.rb
@@ -4,5 +4,6 @@ module ShopProductSink
     belongs_to :shop, class_name: ShopProductSink.shop_class
     has_many :product_variants, dependent: :delete_all
     has_many :options, dependent: :delete_all
+    has_many :images, dependent: :delete_all
   end
 end

--- a/app/models/shop_product_sink/product.rb
+++ b/app/models/shop_product_sink/product.rb
@@ -1,7 +1,7 @@
 module ShopProductSink
   class Product < ActiveRecord::Base
     include ApiCreatable
-    has_many :product_variants
-    has_many :options
+    has_many :product_variants, dependent: :delete_all
+    has_many :options, dependent: :delete_all
   end
 end

--- a/app/models/shop_product_sink/product.rb
+++ b/app/models/shop_product_sink/product.rb
@@ -1,6 +1,7 @@
 module ShopProductSink
   class Product < ActiveRecord::Base
     include ApiCreatable
+    belongs_to :shop, class_name: ShopProductSink.shop_class
     has_many :product_variants, dependent: :delete_all
     has_many :options, dependent: :delete_all
   end

--- a/app/models/shop_product_sink/shop.rb
+++ b/app/models/shop_product_sink/shop.rb
@@ -1,0 +1,22 @@
+module ShopProductSink
+  module Shop
+    class ConfigurationError < StandardError; end
+    extend ActiveSupport::Concern
+
+    def shop
+      return @shop unless @shop.nil?
+
+      shop_class = ShopProductSink.shop_class
+      shop_class = shop_class.constantize unless shop_class.nil?
+      shop_lookup_method = ShopProductSink.shop_lookup_method || :find_by_domain
+      if shop_class && shop_class.respond_to?(shop_lookup_method)
+        # call lookup method with shopify shop domain as argument
+        @shop = shop_class.send(shop_lookup_method, shopify_shop_domain)
+      end
+    end
+
+    def shop_id
+      shop && shop.respond_to?(:id) ? shop.id : nil
+    end
+  end
+end

--- a/app/models/shop_product_sink/webhooks.rb
+++ b/app/models/shop_product_sink/webhooks.rb
@@ -13,19 +13,8 @@ module ShopProductSink
       head :unauthorized
     end
 
-    def shop
-      return @shop unless @shop.nil?
-
-      shop_class = ShopProductSink.shop_class.constantize
-      shop_lookup_method = ShopProductSink.shop_lookup_method || :find_by_domain
-      if shop_class && shop_class.respond_to?(shop_lookup_method)
-        # call lookup method with shopify shop domain as argument
-        @shop = shop_class.send(shop_lookup_method, shopify_shop_domain)
-      end
-    end
-
     def shop_id
-      shop && shop.respond_to?(:id) ? shop.id : nil
+      raise ConfigurationError.new("Unable to determine shop_id. Mixed-in object needs to implement this method")
     end
 
     def application_secret

--- a/app/models/shop_product_sink/webhooks.rb
+++ b/app/models/shop_product_sink/webhooks.rb
@@ -67,7 +67,7 @@ module ShopProductSink
     end
 
     def delete?
-      event = 'delete'
+      event == 'delete'
     end
 
     private

--- a/db/migrate/20150331000257_add_shop_id_to_shop_product_sink_products.rb
+++ b/db/migrate/20150331000257_add_shop_id_to_shop_product_sink_products.rb
@@ -1,0 +1,6 @@
+class AddShopIdToShopProductSinkProducts < ActiveRecord::Migration
+  def change
+    add_column :shop_product_sink_products, :shop_id, :integer
+    add_index :shop_product_sink_products, :shop_id
+  end
+end

--- a/db/migrate/20150403002810_create_shop_product_sink_images.rb
+++ b/db/migrate/20150403002810_create_shop_product_sink_images.rb
@@ -1,0 +1,11 @@
+class CreateShopProductSinkImages < ActiveRecord::Migration
+  def change
+    create_table :shop_product_sink_images do |t|
+      t.integer :position, limit: 2
+      t.integer :product_id
+      t.text :src
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150403041010_add_indices_on_product_relations.rb
+++ b/db/migrate/20150403041010_add_indices_on_product_relations.rb
@@ -1,0 +1,7 @@
+class AddIndicesOnProductRelations < ActiveRecord::Migration
+  def change
+    add_index :shop_product_sink_product_variants, :product_id
+    add_index :shop_product_sink_options, :product_id
+    add_index :shop_product_sink_images, :product_id
+  end
+end

--- a/db/migrate/20150403113138_add_image_id_weight_fields_to_product_variants.rb
+++ b/db/migrate/20150403113138_add_image_id_weight_fields_to_product_variants.rb
@@ -1,0 +1,7 @@
+class AddImageIdWeightFieldsToProductVariants < ActiveRecord::Migration
+  def change
+    add_column :shop_product_sink_product_variants, :weight, :integer
+    add_column :shop_product_sink_product_variants, :weight_unit, :string
+    add_column :shop_product_sink_product_variants, :image_id, :integer
+  end
+end

--- a/lib/shop_product_sink.rb
+++ b/lib/shop_product_sink.rb
@@ -1,4 +1,6 @@
 require "shop_product_sink/engine"
 
 module ShopProductSink
+  mattr_accessor :shop_class
+  mattr_accessor :shop_lookup_method
 end

--- a/lib/shop_product_sink/version.rb
+++ b/lib/shop_product_sink/version.rb
@@ -1,3 +1,3 @@
 module ShopProductSink
-  VERSION = "0.0.1"
+  VERSION = "0.2.1"
 end

--- a/shop_product_sink.gemspec
+++ b/shop_product_sink.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0.2"
+  s.add_dependency "rails", ">= 4.0.2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "shopify_api"

--- a/test/controllers/shop_product_sink/webhooks_controller_test.rb
+++ b/test/controllers/shop_product_sink/webhooks_controller_test.rb
@@ -8,11 +8,18 @@ module ShopProductSink
       @request.env['CONTENT_TYPE'] = 'application/json'
       ShopifyAPI::Base.site = "https://example.myshopify.com/admin"
       WebhooksController.any_instance.stubs(:application_secret).returns('abracadabra')
-      @product_and_relations = [
-        "ShopProductSink::Product.count",
-        "ShopProductSink::ProductVariant.count",
-        "ShopProductSink::Option.count"
-      ]
+    end
+
+    def create_product_with_relations(params, n_relations = 1)
+      ShopProductSink::Product.create(params)
+
+      relation_params = { product_id: params[:id] }
+
+      # create n number of relations
+      n_relations.times do |x|
+        ShopProductSink::ProductVariant.create(relation_params)
+        ShopProductSink::Option.create(relation_params)
+      end
     end
 
     test "when a product creation event occurs" do
@@ -20,7 +27,21 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_create')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/create'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 247905905
-      assert_difference @product_and_relations do
+      assert_difference product_and_relations_difference do
+        post :create, ShopifyJson.read_full_json('product_create')
+        assert_response :ok
+      end
+    end
+
+    test "when a product creation event occurs and the product has already been synchronized" do
+      WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
+      params = { id: 247905905 }
+      create_product_with_relations(params)
+      @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_create')
+      @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/create'
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
+
+      assert_no_difference product_and_relations_difference do
         post :create, ShopifyJson.read_full_json('product_create')
         assert_response :ok
       end
@@ -31,7 +52,7 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_difference @product_and_relations do
+      assert_difference product_and_relations_difference do
         post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
@@ -40,13 +61,11 @@ module ShopProductSink
     test "when a product update event occurs and the product has been synchronized" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
       params = { id: 156731111 }
-      ShopProductSink::Product.create(params)
-      ShopProductSink::ProductVariant.create(product_id: params[:id])
-      ShopProductSink::Option.create(product_id: params[:id])
+      create_product_with_relations(params)
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
-      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_no_difference @product_and_relations do
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
+      assert_no_difference product_and_relations_difference do
         post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
@@ -55,16 +74,12 @@ module ShopProductSink
     test "when a product update event occurs and the product has been synchronized with a different number of variants and options" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
       params = { id: 156731111 }
-      ShopProductSink::Product.create(params)
       # create two options and variants
-      2.times do |x|
-        ShopProductSink::Option.create(product_id: params[:id])
-        ShopProductSink::ProductVariant.create(product_id: params[:id])
-      end
+      create_product_with_relations(params, 2)
 
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
-      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
       full_json = ShopifyJson.read_full_json('product_update')
       assert_no_difference "ShopProductSink::Product.count" do
         post :create, full_json
@@ -80,13 +95,12 @@ module ShopProductSink
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
       # delete webhook json only contains id
       params = { id: 156731111 }
-      ShopProductSink::Product.create(params)
-      ShopProductSink::ProductVariant.create(product_id: params[:id])
-      ShopProductSink::Option.create(product_id: params[:id])
+      create_product_with_relations(params)
+
       @request.env['RAW_POST_DATA'] = ActiveSupport::JSON.encode(params)
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/delete'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
-      assert_difference @product_and_relations, -1 do
+      assert_difference product_and_relations_difference, -1 do
         post :create, params
         assert_response :ok
       end

--- a/test/controllers/shop_product_sink/webhooks_controller_test.rb
+++ b/test/controllers/shop_product_sink/webhooks_controller_test.rb
@@ -19,6 +19,7 @@ module ShopProductSink
       n_relations.times do |x|
         ShopProductSink::ProductVariant.create(relation_params)
         ShopProductSink::Option.create(relation_params)
+        ShopProductSink::Image.create(relation_params)
       end
     end
 
@@ -27,7 +28,10 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_create')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/create'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 247905905
-      assert_difference product_and_relations_difference do
+
+      # Note: Product creation fixture does not include images
+      # we remove Image.count - last item in difference argument
+      assert_difference product_and_relations_difference[0,-1] do
         post :create, ShopifyJson.read_full_json('product_create')
         assert_response :ok
       end

--- a/test/controllers/shop_product_sink/webhooks_controller_test.rb
+++ b/test/controllers/shop_product_sink/webhooks_controller_test.rb
@@ -4,8 +4,15 @@ module ShopProductSink
   class WebhooksControllerTest < ActionController::TestCase
 
     setup do
+      @routes = Engine.routes
+      @request.env['CONTENT_TYPE'] = 'application/json'
       ShopifyAPI::Base.site = "https://example.myshopify.com/admin"
       WebhooksController.any_instance.stubs(:application_secret).returns('abracadabra')
+      @product_and_relations = [
+        "ShopProductSink::Product.count",
+        "ShopProductSink::ProductVariant.count",
+        "ShopProductSink::Option.count"
+      ]
     end
 
     test "when a product creation event occurs" do
@@ -13,8 +20,8 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_create')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/create'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 247905905
-      assert_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_create')
         assert_response :ok
       end
     end
@@ -24,32 +31,63 @@ module ShopProductSink
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
     end
 
     test "when a product update event occurs and the product has been synchronized" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
-      ShopProductSink::Product.create(id: 156731111)
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      ShopProductSink::ProductVariant.create(product_id: params[:id])
+      ShopProductSink::Option.create(product_id: params[:id])
       @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_no_difference "ShopProductSink::Product.count" do
-        post :create, use_route: :shop_product_sink
+      assert_no_difference @product_and_relations do
+        post :create, ShopifyJson.read_full_json('product_update')
         assert_response :ok
       end
     end
 
+    test "when a product update event occurs and the product has been synchronized with a different number of variants and options" do
+      WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      # create two options and variants
+      2.times do |x|
+        ShopProductSink::Option.create(product_id: params[:id])
+        ShopProductSink::ProductVariant.create(product_id: params[:id])
+      end
+
+      @request.env['RAW_POST_DATA'] = ShopifyJson.read_file('product_update')
+      @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
+      full_json = ShopifyJson.read_full_json('product_update')
+      assert_no_difference "ShopProductSink::Product.count" do
+        post :create, full_json
+        assert_response :ok
+      end
+
+      # new count for variants and options should match json fixture file
+      assert_equal full_json["variants"].size, ShopProductSink::ProductVariant.count, "variants count"
+      assert_equal full_json["options"].size, ShopProductSink::Option.count, "options count"
+    end
+
     test "when a product deletion event occurs" do
       WebhooksController.any_instance.expects(:valid_webhook?).returns(true)
-      ShopProductSink::Product.create(id: 156731111)
-      @request.env['RAW_POST_DATA'] = ''
+      # delete webhook json only contains id
+      params = { id: 156731111 }
+      ShopProductSink::Product.create(params)
+      ShopProductSink::ProductVariant.create(product_id: params[:id])
+      ShopProductSink::Option.create(product_id: params[:id])
+      @request.env['RAW_POST_DATA'] = ActiveSupport::JSON.encode(params)
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/delete'
-      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
-      assert_difference "ShopProductSink::Product.count", -1 do
-        post :create, use_route: :shop_product_sink
+      @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = params[:id]
+      assert_difference @product_and_relations, -1 do
+        post :create, params
         assert_response :ok
       end
     end
@@ -59,7 +97,7 @@ module ShopProductSink
       @request.env['HTTP_X_SHOPIFY_TOPIC'] = 'products/update'
       @request.env['HTTP_X_SHOPIFY_PRODUCT_ID'] = 156731111
       @request.env['HTTP_X_SHOPIFY_HMAC_SHA256'] = 'dsfdfasfsdafasdfdsa'
-      post :create, use_route: :shop_product_sink
+      post :create, ShopifyJson.read_full_json('product_update')
       assert_response :unauthorized
     end
   end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Dummy::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
@@ -33,4 +33,7 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Random test order like Rails 5
+  config.active_support.test_order = :random
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,26 +11,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140118171602) do
+ActiveRecord::Schema.define(version: 20150403002810) do
 
-  create_table "shop_product_sink_integration_object_relations", force: true do |t|
+  create_table "shop_product_sink_images", force: :cascade do |t|
+    t.integer  "position",   limit: 2
+    t.integer  "product_id"
+    t.text     "src"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  create_table "shop_product_sink_integration_object_relations", force: :cascade do |t|
     t.integer "integration_object_id"
     t.string  "sku"
     t.string  "option1"
   end
 
-  create_table "shop_product_sink_integration_objects", force: true do |t|
+  create_table "shop_product_sink_integration_objects", force: :cascade do |t|
     t.string  "title"
     t.decimal "price", precision: 10, scale: 2
   end
 
-  create_table "shop_product_sink_options", force: true do |t|
+  create_table "shop_product_sink_options", force: :cascade do |t|
     t.integer "product_id"
     t.string  "name"
     t.integer "position"
   end
 
-  create_table "shop_product_sink_product_variants", force: true do |t|
+  create_table "shop_product_sink_product_variants", force: :cascade do |t|
     t.string   "barcode"
     t.string   "compare_at_price"
     t.string   "fulfillment_service"
@@ -51,7 +59,7 @@ ActiveRecord::Schema.define(version: 20140118171602) do
     t.datetime "updated_at"
   end
 
-  create_table "shop_product_sink_products", force: true do |t|
+  create_table "shop_product_sink_products", force: :cascade do |t|
     t.text     "body_html"
     t.string   "handle"
     t.string   "product_type"
@@ -63,6 +71,9 @@ ActiveRecord::Schema.define(version: 20140118171602) do
     t.string   "vendor"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "shop_id"
   end
+
+  add_index "shop_product_sink_products", ["shop_id"], name: "index_shop_product_sink_products_on_shop_id"
 
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150403041010) do
+ActiveRecord::Schema.define(version: 20150403113138) do
 
   create_table "shop_product_sink_images", force: :cascade do |t|
     t.integer  "position",   limit: 2
@@ -61,6 +61,9 @@ ActiveRecord::Schema.define(version: 20150403041010) do
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "weight"
+    t.string   "weight_unit"
+    t.integer  "image_id"
   end
 
   add_index "shop_product_sink_product_variants", ["product_id"], name: "index_shop_product_sink_product_variants_on_product_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150403002810) do
+ActiveRecord::Schema.define(version: 20150403041010) do
 
   create_table "shop_product_sink_images", force: :cascade do |t|
     t.integer  "position",   limit: 2
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20150403002810) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
   end
+
+  add_index "shop_product_sink_images", ["product_id"], name: "index_shop_product_sink_images_on_product_id"
 
   create_table "shop_product_sink_integration_object_relations", force: :cascade do |t|
     t.integer "integration_object_id"
@@ -37,6 +39,8 @@ ActiveRecord::Schema.define(version: 20150403002810) do
     t.string  "name"
     t.integer "position"
   end
+
+  add_index "shop_product_sink_options", ["product_id"], name: "index_shop_product_sink_options_on_product_id"
 
   create_table "shop_product_sink_product_variants", force: :cascade do |t|
     t.string   "barcode"
@@ -58,6 +62,8 @@ ActiveRecord::Schema.define(version: 20150403002810) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "shop_product_sink_product_variants", ["product_id"], name: "index_shop_product_sink_product_variants_on_product_id"
 
   create_table "shop_product_sink_products", force: :cascade do |t|
     t.text     "body_html"

--- a/test/fixtures/shop_product_sink/images.yml
+++ b/test/fixtures/shop_product_sink/images.yml
@@ -1,0 +1,9 @@
+one:
+  position: 1
+  product_id: 1
+  src: MyText
+
+two:
+  position: 2
+  product_id: 1
+  src: MyText

--- a/test/models/shop_product_sink/image_test.rb
+++ b/test/models/shop_product_sink/image_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module ShopProductSink
+  class ImageTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/test/models/shop_product_sink/product_test.rb
+++ b/test/models/shop_product_sink/product_test.rb
@@ -2,8 +2,26 @@ require 'test_helper'
 
 module ShopProductSink
   class ProductTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    test 'that destroying product deletes all dependent variants and options' do
+    	fake_product_id = 9
+    	fake_product = ShopProductSink::Product.create(id: fake_product_id)
+    	ShopProductSink::ProductVariant.create(product_id: fake_product_id)
+    	ShopProductSink::Option.create(product_id: fake_product_id)
+
+    	assert ShopProductSink::Product.count > 0, "should have at least one product fixture loaded"
+
+    	variants = fake_product.product_variants
+    	options = fake_product.options
+
+    	assert variants.count > 0, "product fixture should have variants"
+    	assert options.count > 0, "product fixture should have options"
+
+      assert_difference "ShopProductSink::Product.count", -1 do
+				fake_product.destroy
+			end
+
+			assert_equal 0, variants.reload.count, "variants count should be 0 after destroy"
+			assert_equal 0, options.reload.count, "options count should be 0 after product destroy"
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,9 +37,13 @@ module ShopifyJson
     File.read(File.expand_path("../fixtures/shopify_json/#{filename}.json", __FILE__))
   end
 
-  def self.read_json(filename, root)
+  def self.read_full_json(filename)
     contents = read_file(filename)
-    ActiveSupport::JSON.decode(contents)[root]
+    ActiveSupport::JSON.decode(contents)
+  end
+
+  def self.read_json(filename, root)
+    read_full_json(filename)[root]
   end
 
   def self.product(filename)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,12 @@ class ShopProductSink::UnitTest < ActiveSupport::TestCase
   end
 end
 
+def product_and_relations_difference
+  ["Product", "ProductVariant", "Option"].map { |model|
+    "ShopProductSink::#{ model }.count"
+  }
+end
+
 module ShopifyJson
   def self.read_file(filename)
     File.read(File.expand_path("../fixtures/shopify_json/#{filename}.json", __FILE__))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "rails/test_help"
 require 'shopify_api'
 require 'pry'
 require 'pry-byebug'
+require 'mocha/mini_test'
 
 Rails.backtrace_cleaner.remove_silencers!
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ class ShopProductSink::UnitTest < ActiveSupport::TestCase
 end
 
 def product_and_relations_difference
-  ["Product", "ProductVariant", "Option"].map { |model|
+  ["Product", "ProductVariant", "Option", "Image"].map { |model|
     "ShopProductSink::#{ model }.count"
   }
 end

--- a/test/unit/shop_product_sink/importers/product_test.rb
+++ b/test/unit/shop_product_sink/importers/product_test.rb
@@ -25,12 +25,12 @@ module ShopProductSink
       end
 
       test "that it retrieves by default use a page size of #{Importers::Product::PAGE_SIZE}" do
-        ShopifyAPI::Product.expects(:find).with(:all, query: {page: 1, limit: Importers::Product::PAGE_SIZE}).returns([])
+        ShopifyAPI::Product.expects(:find).with(:all, params: {page: 1, limit: Importers::Product::PAGE_SIZE}).returns([])
         assert_equal [], importer.retrieve
       end
 
       test "can override the default page size" do
-        ShopifyAPI::Product.expects(:find).with(:all, query: {page: 1, limit: 1}).returns([])
+        ShopifyAPI::Product.expects(:find).with(:all, params: {page: 1, limit: 1}).returns([])
         assert_equal [], importer.retrieve(limit: 1)
       end
 
@@ -43,7 +43,7 @@ module ShopProductSink
         results = [ShopifyJson.product('justmops_product')]
         ShopifyAPI::Product.expects(:find).returns(results)
 
-        assert_difference "ShopProductSink::Product.count" do
+        assert_difference product_and_relations_difference do
           importer.import
         end
       end


### PR DESCRIPTION
This time the test suite is passing :100:

Pull request mainly adds `Image` model and `:images` `Product` relation. Also:
- fixed bug in product import test
- some refactoring in webhooks controller test code
- added indices on `product_id` for faster lookups of product relations
- updated README with clearer upgrade instructions
- bumped version number
- added `image_id`, `weight`, `weight_unit` fields to product variants