### PR TITLE
Set ShopifyAPI::Base.site in WebhooksController, fix test

### DIFF
--- a/app/controllers/shop_product_sink/webhooks_controller.rb
+++ b/app/controllers/shop_product_sink/webhooks_controller.rb
@@ -5,6 +5,8 @@ module ShopProductSink
     include ShopProductSink::Webhooks
     include ShopProductSink::Shop
 
+    before_action :shopify_resource_setup
+
     def create
       handle_creation
       handle_update
@@ -39,6 +41,10 @@ module ShopProductSink
 
     def resource_class
       ShopProductSink::Product
+    end
+
+    def shopify_resource_setup
+      ShopifyAPI::Base.site = '/' if ShopifyAPI::Base.site.nil?
     end
 
     def shopify_resource

--- a/test/controllers/shop_product_sink/webhooks_controller_test.rb
+++ b/test/controllers/shop_product_sink/webhooks_controller_test.rb
@@ -6,7 +6,6 @@ module ShopProductSink
     setup do
       @routes = Engine.routes
       @request.env['CONTENT_TYPE'] = 'application/json'
-      ShopifyAPI::Base.site = "https://example.myshopify.com/admin"
       WebhooksController.any_instance.stubs(:application_secret).returns('abracadabra')
     end
 


### PR DESCRIPTION
`shopify_resource`'s structure is used to extract resource relations and map them to database records.
It does not start or need a `ShopifyAPI` session, therefore `ShopifyAPI::Base.site` is nil by default.
ActiveResource::Base then calls site.path in its prefix method, which would raise NoMethodError on NilClass.

Users are not told to set `ShopifyAPI::Base.site` anywhere during their setup, so we should not set it in `WebhooksControllerTest`, either. Now the test will not pass without setting `ShopifyAPI::Base.site` in the controller.
