### PR TITLE
Migrate database id columns to 64-bit integer

### DIFF
--- a/db/migrate/20150526085214_change_resource_id_columns_to_big_int.rb
+++ b/db/migrate/20150526085214_change_resource_id_columns_to_big_int.rb
@@ -1,0 +1,28 @@
+class ChangeResourceIdColumnsToBigInt < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        # change columns that refer to resource IDs created in Shopify to 64-bit (8-byte) integers
+        change_column :shop_product_sink_images, :product_id, :integer, limit: 8
+        change_column :shop_product_sink_options, :product_id, :integer, limit: 8
+        change_column :shop_product_sink_product_variants, :product_id, :integer, limit: 8
+        change_column :shop_product_sink_product_variants, :image_id, :integer, limit: 8
+        change_column :shop_product_sink_images, :id, :integer, limit: 8
+        change_column :shop_product_sink_options, :id, :integer, limit: 8
+        change_column :shop_product_sink_product_variants, :id, :integer, limit: 8
+        change_column :shop_product_sink_products, :id, :integer, limit: 8
+      end
+
+      dir.down do
+        change_column :shop_product_sink_images, :product_id, :integer
+        change_column :shop_product_sink_options, :product_id, :integer
+        change_column :shop_product_sink_product_variants, :product_id, :integer
+        change_column :shop_product_sink_product_variants, :image_id, :integer
+        change_column :shop_product_sink_images, :id, :integer
+        change_column :shop_product_sink_options, :id, :integer
+        change_column :shop_product_sink_product_variants, :id, :integer
+        change_column :shop_product_sink_products, :id, :integer
+      end
+    end
+  end
+end

--- a/db/migrate/20150526085214_change_resource_id_columns_to_big_int.rb
+++ b/db/migrate/20150526085214_change_resource_id_columns_to_big_int.rb
@@ -1,5 +1,8 @@
 class ChangeResourceIdColumnsToBigInt < ActiveRecord::Migration
   def change
+    # SQLite supports 1 to 8-byte integer sizes automatically - do nothing
+    return if ActiveRecord::Base.connection.instance_of? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+
     reversible do |dir|
       dir.up do
         # change columns that refer to resource IDs created in Shopify to 64-bit (8-byte) integers

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150403113138) do
+ActiveRecord::Schema.define(version: 20150526085214) do
 
   create_table "shop_product_sink_images", force: :cascade do |t|
     t.integer  "position",   limit: 2


### PR DESCRIPTION
Shopify product variant IDs have recently crossed over the 32-bit threshold into 64-bit territory. At 32-bit, you'll see errors when importing or receiving webhooks for new products.

All `ShopProductSink` tables reflecting shopify resources (products, options, variants, images) need their id columns upgraded to 64-bit integer to future-proof them.

Any SQLite database is an exception to this (see 118ca0f comments)
